### PR TITLE
Add profile detail page

### DIFF
--- a/core/test_views.py
+++ b/core/test_views.py
@@ -113,3 +113,11 @@ class TestViews:
         user.refresh_from_db()
         assert user.username == 'novo'
         assert user.email == 'novo@example.com'
+
+    def test_profile_detail_view(self, client, user):
+        client.force_login(user)
+        response = client.get(reverse('profile_detail'))
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert user.username in content
+        assert user.email in content

--- a/core/urls.py
+++ b/core/urls.py
@@ -6,7 +6,8 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('register/', views.register, name='register'),
-    path('perfil/', views.profile_edit, name='profile_edit'),
+    path('perfil/', views.profile_detail, name='profile_detail'),
+    path('perfil/editar/', views.profile_edit, name='profile_edit'),
     path('logout/', views.logout_view, name='logout'),
     
     # URLs para Transações

--- a/core/views.py
+++ b/core/views.py
@@ -49,6 +49,11 @@ def logout_view(request):
 
 
 @login_required
+def profile_detail(request):
+    return render(request, 'core/profile_detail.html', {'user_obj': request.user, 'title': 'Perfil'})
+
+
+@login_required
 def profile_edit(request):
     if request.method == 'POST':
         form = UserUpdateForm(request.POST, instance=request.user)

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,7 @@
                 </div>
                 <div class="flex items-center gap-4">
                     <span class="text-gray-700 dark:text-gray-300">{{ user.username }}</span>
-                    <a href="{% url 'profile_edit' %}" class="text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Perfil</a>
+                    <a href="{% url 'profile_detail' %}" class="text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Perfil</a>
                     <form method="post" action="{% url 'logout' %}">
                             {% csrf_token %}
                             <button type="submit" class="text-sm text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white bg-transparent border-none p-0 m-0 cursor-pointer">

--- a/templates/core/profile_detail.html
+++ b/templates/core/profile_detail.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }} - Budgetsize{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+  <div class="bg-white dark:bg-gray-800 shadow rounded-lg">
+    <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700">
+      <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">
+        {{ title }}
+      </h3>
+    </div>
+    <div class="px-4 py-5 sm:px-6 space-y-4">
+      <p><strong>Usuário:</strong> {{ user_obj.username }}</p>
+      <p><strong>Nome:</strong> {{ user_obj.get_full_name|default:"-" }}</p>
+      <p><strong>Email:</strong> {{ user_obj.email }}</p>
+      <div class="flex justify-end">
+        <a href="{% url 'profile_edit' %}" class="inline-flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+          Editar Perfil
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add view for user profile details
- add profile detail template
- link to profile in navigation
- provide URLs for profile detail and edit
- test the profile detail view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6873540a39e0832ba5e7645d6ea3020c